### PR TITLE
Fixes race condition on non blocking send to job channel

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -113,7 +113,7 @@ func (w *Worker) getNextJob(jobCh chan *RawJob, tubes *beanstalk.TubeSet) {
 	}
 
 	if err != nil {
-		w.sendJobResult(jobCh, job)
+		jobCh <- job
 		return
 	}
 
@@ -121,21 +121,12 @@ func (w *Worker) getNextJob(jobCh chan *RawJob, tubes *beanstalk.TubeSet) {
 	stats, err := tubes.Conn.StatsJob(job.id)
 	if err != nil {
 		job.err = err
-		w.sendJobResult(jobCh, job)
+		jobCh <- job
 		return
 	}
 
 	job.tube = stats["tube"]
-	w.sendJobResult(jobCh, job)
-}
-
-// sendJobResult sends the job data back to the worker using a non-blocking channel.
-func (w *Worker) sendJobResult(jobCh chan *RawJob, job *RawJob) {
-	//Non-blocking send to channel.
-	select {
-	case jobCh <- job:
-	default:
-	}
+	jobCh <- job
 }
 
 // subHandler finds and executes any subcriber function for a job.


### PR DESCRIPTION
Fixes race condition where a non-blocking send on a channel causes a job to be lost and the main worker loop hangs waiting for the job that never comes

