### PR TITLE
The logger can be replaced (or not used)

### DIFF
--- a/beanstalkworker/logger.go
+++ b/beanstalkworker/logger.go
@@ -1,0 +1,59 @@
+package beanstalkworker
+
+import (
+	"log"
+	"os"
+)
+
+type Logger interface {
+	Debug(v ...interface{})
+	Debugf(format string, args ...interface{})
+	Info(v ...interface{})
+	Infof(format string, args ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, args ...interface{})
+	Error(v ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatal(v ...interface{})
+	Fatalf(format string, args ...interface{})
+}
+
+type StdLogger struct {
+	*log.Logger
+}
+
+func NewStdLogger() Logger {
+	return &StdLogger{log.New(os.Stdout, "Faktory ", log.LstdFlags)}
+}
+
+func (l *StdLogger) Debug(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Debugf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Error(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Errorf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Info(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Infof(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Warn(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Warnf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -3,7 +3,6 @@ package beanstalkworker
 import "time"
 import "github.com/tomponline/beanstalk"
 import "fmt"
-import "log"
 
 // RawJob represents the raw job data that is returned by beanstalkd.
 type RawJob struct {
@@ -20,6 +19,7 @@ type RawJob struct {
 	age         time.Duration
 	returnPrio  uint32
 	returnDelay time.Duration
+	log 		Logger
 }
 
 // Delete function deletes the job from the queue.
@@ -95,10 +95,10 @@ func (job *RawJob) GetConn() *beanstalk.Conn {
 
 // LogError function logs an error messagge regarding the job.
 func (job *RawJob) LogError(a ...interface{}) {
-	log.Print("Tube: ", job.tube, ", Job: ", job.id, ": Error: ", fmt.Sprint(a...))
+	job.log.Info("Tube: ", job.tube, ", Job: ", job.id, ": Error: ", fmt.Sprint(a...))
 }
 
 // LogInfo function logs an info messagge regarding the job.
 func (job *RawJob) LogInfo(a ...interface{}) {
-	log.Print("Tube: ", job.tube, ", Job: ", job.id, ": ", fmt.Sprint(a...))
+	job.log.Info("Tube: ", job.tube, ", Job: ", job.id, ": ", fmt.Sprint(a...))
 }

--- a/beanstalkworker_demo/beanstalkworker_demo.go
+++ b/beanstalkworker_demo/beanstalkworker_demo.go
@@ -1,13 +1,18 @@
 package main
 
-import "github.com/tomponline/beanstalkworker/beanstalkworker"
-import "context"
-import "os"
-import "os/signal"
-import "syscall"
-import "log"
+import (
+	"beanstalkworker/beanstalkworker"
+	"os"
+	"os/signal"
+	"syscall"
+	"context"
+)
+
+var log = beanstalkworker.NewStdLogger()
 
 func main() {
+
+
 	//Setup context for cancelling beanstalk worker.
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -44,7 +49,7 @@ func signalHandler(cancel context.CancelFunc) {
 	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
 	for {
 		<-sigc
-		log.Print("Got signal, cancelling context")
+		log.Info("Got signal, cancelling context")
 		cancel()
 	}
 }

--- a/beanstalkworker_demo/job1.go
+++ b/beanstalkworker_demo/job1.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/tomponline/beanstalkworker/beanstalkworker"
+import "beanstalkworker/beanstalkworker"
 import "time"
 import "fmt"
 


### PR DESCRIPTION
Introduced the logginh interface, so logger can be replaced with something else than the default log package. 
**beanstalkworker_demo** updated as well.