### PR TITLE
Add missing SetLogger method to JobManager interface

### DIFF
--- a/beanstalkworker/job.go
+++ b/beanstalkworker/job.go
@@ -19,4 +19,5 @@ type JobManager interface {
 	GetConn() *beanstalk.Conn
 	SetReturnPriority(prio uint32)
 	SetReturnDelay(delay time.Duration)
+	SetLogger(cl CustomLogger)
 }


### PR DESCRIPTION
This PR is related to https://github.com/tomponline/beanstalkworker/pull/23 in which the method `SetLogger` was added to the `RawJob`. In order to actually set the `Logger` the method need to be available in the `JobManager` interface too. 