### PR TITLE
Add method to initialise a raw job with a default logger

### DIFF
--- a/beanstalkworker/job.go
+++ b/beanstalkworker/job.go
@@ -19,5 +19,4 @@ type JobManager interface {
 	GetConn() *beanstalk.Conn
 	SetReturnPriority(prio uint32)
 	SetReturnDelay(delay time.Duration)
-	SetLogger(cl CustomLogger)
 }

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -22,10 +22,18 @@ type RawJob struct {
 	log         *Logger
 }
 
-// Initialise a new RawJob with default logger set
-func NewRawJob() *RawJob {
+// Initialise a new empty RawJob with a custom logger
+// Useful for testing methods that log messages on the job
+func NewEmptyJob(cl CustomLogger) *RawJob {
+	logger := &Logger{
+		Info:   cl.Info,
+		Infof:  cl.Infof,
+		Error:  cl.Error,
+		Errorf: cl.Errorf,
+	}
+
 	return &RawJob{
-		log: NewDefaultLogger(),
+		log: logger,
 	}
 }
 
@@ -108,12 +116,4 @@ func (job *RawJob) LogError(a ...interface{}) {
 // LogInfo function logs an info message regarding the job.
 func (job *RawJob) LogInfo(a ...interface{}) {
 	job.log.Info("Tube: ", job.tube, ", Job: ", job.id, ": ", fmt.Sprint(a...))
-}
-
-// SetLogger switches the jobs logger to a custom logger.
-func (job *RawJob) SetLogger(cl CustomLogger) {
-	job.log.Error = cl.Error
-	job.log.Errorf = cl.Errorf
-	job.log.Info = cl.Info
-	job.log.Infof = cl.Infof
 }

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -22,6 +22,13 @@ type RawJob struct {
 	log         *Logger
 }
 
+// Initialise a new RawJob with default logger set
+func NewRawJob() *RawJob {
+	return &RawJob{
+		log: NewDefaultLogger(),
+	}
+}
+
 // Delete function deletes the job from the queue.
 func (job *RawJob) Delete() {
 	if err := job.conn.Delete(job.id); err != nil {


### PR DESCRIPTION
Currently it is impossible to set the logger on an initialised raw job (for testing purposes) as the log property is unexported and initialised as nil.

This PR adds a method to initialise a raw job with a default logger set.