### PR TITLE
Introduce SetUnmarshalErrorAction in the beanstalk worker

### DIFF
--- a/beanstalkworker/logger.go
+++ b/beanstalkworker/logger.go
@@ -2,6 +2,7 @@ package beanstalkworker
 
 import "log"
 
+// CustomLogger provides support for the creation of custom logging
 type CustomLogger interface {
 	Info(v ...interface{})
 	Infof(format string, args ...interface{})
@@ -9,6 +10,7 @@ type CustomLogger interface {
 	Errorf(format string, args ...interface{})
 }
 
+// Logger provides support for standard logging
 type Logger struct {
 	Info   func(v ...interface{})
 	Infof  func(format string, v ...interface{})

--- a/beanstalkworker/logger.go
+++ b/beanstalkworker/logger.go
@@ -2,7 +2,7 @@ package beanstalkworker
 
 import "log"
 
-// CustomLogger provides support for the creation of custom logging
+// CustomLogger provides support for the creation of custom logging.
 type CustomLogger interface {
 	Info(v ...interface{})
 	Infof(format string, args ...interface{})
@@ -10,7 +10,7 @@ type CustomLogger interface {
 	Errorf(format string, args ...interface{})
 }
 
-// Logger provides support for standard logging
+// Logger provides support for standard logging.
 type Logger struct {
 	Info   func(v ...interface{})
 	Infof  func(format string, v ...interface{})

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -124,3 +124,17 @@ func (job *RawJob) LogError(a ...interface{}) {
 func (job *RawJob) LogInfo(a ...interface{}) {
 	job.log.Info("Tube: ", job.tube, ", Job: ", job.id, ": ", fmt.Sprint(a...))
 }
+
+// unmarshalErrorAction handles unmarshal error, depending on the user choice
+func (job *RawJob) unmarshalErrorAction(unmarshalErrorAction string) {
+	switch unmarshalErrorAction {
+	case ActionDeleteJob:
+		job.Delete()
+	case ActionBuryJob:
+		job.Bury()
+	default:
+		// Release as the default option as this would be the safest option for the user.
+		// We don't want someone to have some jobs being deleted if they are not aware of it.
+		job.Release()
+	}
+}

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -4,6 +4,13 @@ import "time"
 import "github.com/tomponline/beanstalk"
 import "fmt"
 
+const (
+	// Actions the user can choose in case of an unmarshal error.
+	ActionDeleteJob  = "Delete"
+	ActionBuryJob    = "Bury"
+	ActionReleaseJob = "Release"
+)
+
 // RawJob represents the raw job data that is returned by beanstalkd.
 type RawJob struct {
 	id          uint64

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -29,8 +29,8 @@ type RawJob struct {
 	log         *Logger
 }
 
-// NewEmptyJob initialises a new empty RawJob with a custom logger
-// Useful for testing methods that log messages on the job
+// NewEmptyJob initialises a new empty RawJob with a custom logger.
+// Useful for testing methods that log messages on the job.
 func NewEmptyJob(cl CustomLogger) *RawJob {
 	logger := &Logger{
 		Info:   cl.Info,
@@ -125,7 +125,7 @@ func (job *RawJob) LogInfo(a ...interface{}) {
 	job.log.Info("Tube: ", job.tube, ", Job: ", job.id, ": ", fmt.Sprint(a...))
 }
 
-// unmarshalErrorAction handles unmarshal error, depending on the user choice
+// unmarshalErrorAction handles unmarshal error, depending on the user choice.
 func (job *RawJob) unmarshalErrorAction(unmarshalErrorAction string) {
 	switch unmarshalErrorAction {
 	case ActionDeleteJob:

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -4,8 +4,8 @@ import "time"
 import "github.com/tomponline/beanstalk"
 import "fmt"
 
+// Actions the user can choose in case of an unmarshal error.
 const (
-	// Actions the user can choose in case of an unmarshal error.
 	ActionDeleteJob  = "Delete"
 	ActionBuryJob    = "Bury"
 	ActionReleaseJob = "Release"
@@ -29,7 +29,7 @@ type RawJob struct {
 	log         *Logger
 }
 
-// Initialise a new empty RawJob with a custom logger
+// NewEmptyJob initialises a new empty RawJob with a custom logger
 // Useful for testing methods that log messages on the job
 func NewEmptyJob(cl CustomLogger) *RawJob {
 	logger := &Logger{

--- a/beanstalkworker/rawJob.go
+++ b/beanstalkworker/rawJob.go
@@ -6,9 +6,9 @@ import "fmt"
 
 // Actions the user can choose in case of an unmarshal error.
 const (
-	ActionDeleteJob  = "Delete"
-	ActionBuryJob    = "Bury"
-	ActionReleaseJob = "Release"
+	ActionDeleteJob  = "delete"
+	ActionBuryJob    = "bury"
+	ActionReleaseJob = "release"
 )
 
 // RawJob represents the raw job data that is returned by beanstalkd.

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -1,12 +1,14 @@
 package beanstalkworker
 
-import "time"
-import "github.com/tomponline/beanstalk"
-import "encoding/json"
-import "reflect"
-import "context"
-import "strconv"
-import "sync"
+import (
+	"context"
+	"encoding/json"
+	"github.com/tomponline/beanstalk"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+)
 
 // Handler provides an interface type for callback functions.
 type Handler interface{}

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -31,7 +31,7 @@ func NewWorker(addr string) *Worker {
 		addr:                 addr,
 		tubeSubs:             make(map[string]func(*RawJob)),
 		log:                  NewDefaultLogger(),
-		unmarshalErrorAction: ActionReleaseJob, // It ensures the job is released to the queue by default for unmarshal error
+		unmarshalErrorAction: ActionReleaseJob, // It ensures the job is released to the queue by default for unmarshal error.
 	}
 }
 

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -98,7 +98,7 @@ func (w *Worker) SetUnmarshalErrorAction(action string) {
 	// If this action is different than Delete, Bury or Release, the last one will be chosen
 	// as the default action in case of an unmarshal error, via the method job.unmarshalErrorHandling.
 	if action != ActionDeleteJob && action != ActionBuryJob {
-		w.unmarshalErrorAction = ActionReleaseJob // By safety only and to keep log message conistent with the action
+		w.unmarshalErrorAction = ActionReleaseJob // By safety only and to keep log message consistent with the action.
 		return
 	}
 	w.unmarshalErrorAction = action

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -64,7 +64,7 @@ func (w *Worker) Subscribe(tube string, cb Handler) {
 
 		if err := json.Unmarshal(*job.body, dataPtr.Interface()); err != nil {
 			job.LogError("Error decoding JSON for job: ", err, ", '", string(*job.body), "', "+w.unmarshalErrorAction+"...")
-			// Delete, Bury or Release (default behaviour) the job to the queue, depending on the user choice
+			// Delete, Bury or Release (default behaviour) the job to the queue, depending on the user choice.
 			job.unmarshalErrorAction(w.unmarshalErrorAction)
 			return
 		}

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -63,8 +63,9 @@ func (w *Worker) Subscribe(tube string, cb Handler) {
 		dataPtr := reflect.New(dataType)
 
 		if err := json.Unmarshal(*job.body, dataPtr.Interface()); err != nil {
-			job.LogError("Error decoding JSON for job: ", err, ", '", string(*job.body), "', releasing...")
-			job.Release()
+			job.LogError("Error decoding JSON for job: ", err, ", '", string(*job.body), "', "+w.unmarshalErrorAction+"...")
+			// Delete, Bury or Release (default behaviour) the job to the queue, depending on the user choice
+			job.unmarshalErrorAction(w.unmarshalErrorAction)
 			return
 		}
 

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -93,6 +93,13 @@ func (w *Worker) Run(ctx context.Context) {
 	w.wg.Wait() //Block here until all workers cleanly finish.
 }
 
+// SetUnmarshalErrorAction defines what to do if there is an unmarshal error.
+func (w *Worker) SetUnmarshalErrorAction(action string) {
+	// If this action is different than Delete, Bury or Release, the last one will be chosen
+	// as the default action in case of an unmarshal error, via the method job.unmarshalErrorHandling.
+	w.unmarshalErrorAction = action
+}
+
 // startWorker activates a single worker and attempts to maintain a connection to the beanstalkd server.
 func (w *Worker) startWorker(ctx context.Context) {
 	defer w.log.Info("Worker stopped!")

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -16,20 +16,22 @@ type Handler interface{}
 // Worker represents a single process that is connecting to beanstalkd
 // and is consuming jobs from one or more tubes.
 type Worker struct {
-	addr       string
-	tubeSubs   map[string]func(*RawJob)
-	numWorkers int
-	wg         sync.WaitGroup
-	log        *Logger
+	addr                 string
+	tubeSubs             map[string]func(*RawJob)
+	numWorkers           int
+	wg                   sync.WaitGroup
+	log                  *Logger
+	unmarshalErrorAction string
 }
 
 // NewWorker creates a new worker process,
 // but does not actually connect to beanstalkd server yet.
 func NewWorker(addr string) *Worker {
 	return &Worker{
-		addr:     addr,
-		tubeSubs: make(map[string]func(*RawJob)),
-		log:      NewDefaultLogger(),
+		addr:                 addr,
+		tubeSubs:             make(map[string]func(*RawJob)),
+		log:                  NewDefaultLogger(),
+		unmarshalErrorAction: ActionReleaseJob, // It ensures the job is released to the queue by default for unmarshal error
 	}
 }
 

--- a/beanstalkworker/worker.go
+++ b/beanstalkworker/worker.go
@@ -97,6 +97,10 @@ func (w *Worker) Run(ctx context.Context) {
 func (w *Worker) SetUnmarshalErrorAction(action string) {
 	// If this action is different than Delete, Bury or Release, the last one will be chosen
 	// as the default action in case of an unmarshal error, via the method job.unmarshalErrorHandling.
+	if action != ActionDeleteJob && action != ActionBuryJob {
+		w.unmarshalErrorAction = ActionReleaseJob // By safety only and to keep log message conistent with the action
+		return
+	}
 	w.unmarshalErrorAction = action
 }
 

--- a/beanstalkworker_demo/beanstalkworker_demo.go
+++ b/beanstalkworker_demo/beanstalkworker_demo.go
@@ -24,6 +24,10 @@ func main() {
 	//Set concurrent worker threads to 2.
 	bsWorker.SetNumWorkers(2)
 
+	//Job is deleted from the queue if unmarshal error appears. We can
+	//decide to bury or release (default behaviour) it as well.
+	bsWorker.SetUnmarshalErrorAction(beanstalkworker.ActionDeleteJob)
+
 	//Define a common value (example a shared database connection)
 	commonVar := "some common value"
 

--- a/beanstalkworker_demo/beanstalkworker_demo.go
+++ b/beanstalkworker_demo/beanstalkworker_demo.go
@@ -59,7 +59,7 @@ func signalHandler(cancel context.CancelFunc) {
 
 //Custom Logging Example
 
-//MyLogger provides custom logging
+//MyLogger provides custom logging.
 type MyLogger struct {
 }
 

--- a/beanstalkworker_demo/beanstalkworker_demo.go
+++ b/beanstalkworker_demo/beanstalkworker_demo.go
@@ -59,22 +59,27 @@ func signalHandler(cancel context.CancelFunc) {
 
 //Custom Logging Example
 
+//MyLogger provides custom logging
 type MyLogger struct {
 }
 
+//Info logs a custom info message regarding the job.
 func (l *MyLogger) Info(v ...interface{}) {
 	log.Print("MyInfo: ", fmt.Sprint(v...))
 }
 
+//Infof logs a custom info message regarding the job.
 func (l *MyLogger) Infof(format string, v ...interface{}) {
 	format = "MyInfof: " + format
 	log.Print(fmt.Sprintf(format, v...))
 }
 
+//Error logs a custom error message regarding the job.
 func (l *MyLogger) Error(v ...interface{}) {
 	log.Print("MyError: ", fmt.Sprint(v...))
 }
 
+//Errorf logs a custom error message regarding the job.
 func (l *MyLogger) Errorf(format string, v ...interface{}) {
 	format = "MyErrorf: " + format
 	log.Print(fmt.Sprintf(format, v...))


### PR DESCRIPTION
**Original issue:** https://github.com/tomponline/beanstalkworker/issues/26

If there is an unmarshal error in the worker,

https://github.com/tomponline/beanstalkworker/blob/f880af6af406bae85607cffb56c63e34cc3b0ab9/beanstalkworker/worker.go#L61
```go
		if err := json.Unmarshal(*job.body, dataPtr.Interface()); err != nil {
			job.LogError("Error decoding JSON for job: ", err, ", '", string(*job.body), "', releasing...")
			job.Release()
			return
		}
```
the job is released by default. This is not ideal as the job can entry an infinity loop. The user might want the job to be buried or deleted in such case.


The goal of this PR is to introduce a new method for the worker, called `SetUnmarshalErrorAction`, that could let the user decide which action to take (delete, bury or release as the default choice). In order to accomplish that, the worker struct has a new field `unmarshalErrorAction` that will remember the user choice.

Then, the job struct can apply the user's decision if a unmarshal error appears via the new method `unmarshalErrorAction`.

The `beanstalkworker_demo.go` has been updated with an example.

**Manual testing**:

Using a worker without using the `SetUnmarshalErrorAction`:
```
Error: Error decoding JSON for job: json: cannot unmarshal number into Go value of type string, 'job data..., Release...
```
It's released as this is the default behaviour.

With 
```diff
        // initializing bsWorker
        bsWorker := beanstalkworker.NewWorker(*beanstalkd)
-
+       bsWorker.SetUnmarshalErrorAction(beanstalkworker.ActionDeleteJob)
```
:
```
Error: Error decoding JSON for job: json: cannot unmarshal number into Go value of type string, job data, Delete...
```
It's deleted (I checked manually)

With
```diff
        // initializing bsWorker
        bsWorker := beanstalkworker.NewWorker(*beanstalkd)
-
+       bsWorker.SetUnmarshalErrorAction(beanstalkworker.ActionBuryJob)
```
: 
```
Error: Error decoding JSON for job: json: cannot unmarshal number into Go value of type string, '{"igrp":19,"rowId":"545247","callDatetime":"2018-11-30 09:15:32"}#015#012', Bury...
```

It's bury (checked manually as well)
