### PR TITLE
Add a link to GoDoc  to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![GoDoc](https://godoc.org/github.com/tomponline/beanstalkworker/beanstalkworker?status.svg)](https://godoc.org/github.com/tomponline/beanstalkworker/beanstalkworker)
 # beanstalkworker
 A helper library for creating beanstalkd consumer processes.
 


### PR DESCRIPTION
Add a link to GoDoc to the README file. It can help to understand what's the package is doing and providing.

https://godoc.org/github.com/tomponline/beanstalkworker/beanstalkworker