### PR TITLE
Adds beanstalkworker with context example

### DIFF
--- a/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
+++ b/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
@@ -13,7 +13,11 @@ import (
 )
 
 const (
+	// Application name for logging
 	appName = "beanstalkworker-with-context"
+
+	// The import queue we want to read from
+	importQueue = "import-jobs"
 )
 
 var (
@@ -71,7 +75,7 @@ func runWorker(ctx context.Context) {
 	bsWorker.SetNumWorkers(*numWorkers)
 
 	// Subscribe to jobs from our queue
-	bsWorker.Subscribe("import-jobs", func(jobMgr beanstalkworker.JobManager, jobData ImportJobData) {
+	bsWorker.Subscribe(importQueue, func(jobMgr beanstalkworker.JobManager, jobData ImportJobData) {
 		// Set up a new 'import' job handler, attaching the job manager and job data to it
 		// ImportJobHandler embeds the beanstalkworker.JobManager to expose job control methods
 		jh := ImportJobHandler{

--- a/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
+++ b/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"log/syslog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/tomponline/beanstalkworker"
+)
+
+const (
+	appName = "beanstalkworker-with-context"
+)
+
+var (
+	// Beanstalk related config
+	beanstalkAddr = flag.String("beanstalkAddr", "127.0.0.1:11300", "Address of the beanstalk server")
+	numWorkers    = flag.Int("numWorkers", 2, "Number of concurrent workers to run")
+)
+
+func main() {
+	setUpSyslog(appName)
+
+	// Log the start time and defer the finishing log line
+	log.Printf("Starting %s", appName)
+	defer log.Printf("Finished %s", appName)
+
+	// Parse our config flags
+	flag.Parse()
+
+	// Setup a context for stopping the worker when the program exits
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the signal handler to catch system signals and shutdown cleanly
+	go signalHandler(cancel)
+
+	// Run the beanstalk worker
+	runWorker(ctx)
+}
+
+//setUpSyslog sets up syslog with a application name suffix
+func setUpSyslog(tag string) {
+	log.SetFlags(0)
+	syslogWriter, err := syslog.New(syslog.LOG_INFO, tag)
+	if err == nil {
+		log.SetOutput(syslogWriter)
+	}
+}
+
+//signalHandler function responds to SIGUP, SIGTERM signals to cleanly shutdown worker using context
+func signalHandler(cancel context.CancelFunc) {
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+	for {
+		<-sigc
+		log.Print("Got signal, cancelling context")
+		cancel()
+	}
+}
+
+//runWorker runs the beanstalk worker with a context
+func runWorker(ctx context.Context) {
+	// Initialise the worker
+	bsWorker := beanstalkworker.NewWorker(*beanstalkAddr)
+
+	// Set the number of concurrent workers
+	bsWorker.SetNumWorkers(*numWorkers)
+
+	// Subscribe to jobs from our queue
+	bsWorker.Subscribe("import-jobs", func(jobMgr beanstalkworker.JobManager, jobData ImportJobData) {
+		// Set up a new 'import' job handler, attaching the job manager and job data to it
+		// ImportJobHandler embeds the beanstalkworker.JobManager to expose job control methods
+		jh := ImportJobHandler{
+			JobManager: jobMgr,
+			jobData:    jobData,
+		}
+
+		// Run the job handler for this job
+		jh.Run()
+	})
+
+	// Run the worker, this call blocks until the context is cancelled
+	// The beanstalkworker package takes care of reconnecting to beanstalk automatically
+	bsWorker.Run(ctx)
+}

--- a/examples/beanstalkworker-with-context/import-job.go
+++ b/examples/beanstalkworker-with-context/import-job.go
@@ -8,6 +8,7 @@ import (
 )
 
 // ImportJobData represents the job data that arrives from the import-jobs queue
+// we'll use map[string]string to keep the transport encoding simple for interoperability
 type ImportJobData map[string]string
 
 // ImportJobHandler contains all the helpers needed to process a job
@@ -44,6 +45,7 @@ func (job *ImportJobHandler) Run() {
 	job.Delete()
 }
 
+// validates job data before processing to ensure required job data is present
 func (job *ImportJobHandler) validateJobData() error {
 	// Required fields on our job
 	requiredFields := []string{"type"}

--- a/examples/beanstalkworker-with-context/import-job.go
+++ b/examples/beanstalkworker-with-context/import-job.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tomponline/beanstalkworker"
+)
+
+// ImportJobData represents the job data that arrives from the import-jobs queue
+type ImportJobData map[string]string
+
+// ImportJobHandler contains all the helpers needed to process a job
+type ImportJobHandler struct {
+	// Embed the job manager
+	beanstalkworker.JobManager
+
+	jobData ImportJobData
+}
+
+// Run is executed for every job
+func (job *ImportJobHandler) Run() {
+	// Validate our job data, we can't process invalid jobs
+	if err := job.validateJobData(); err != nil {
+		// Attempt to re-marshal our job data and log it
+		jobStr, mrshErr := json.Marshal(job.jobData)
+		if mrshErr != nil {
+			// We shouldn't ever have a problem marshalling a map[string]string
+			// but never say never
+			job.LogError("Could not re-marshal job data: ", mrshErr)
+		}
+
+		// Log the job data then delete the job, we will never be able to process this job
+		// as it requires manual intervention
+		job.LogError("Job data is invalid: ", err, ", deleting job: ", string(jobStr))
+		job.Delete()
+
+		return
+	}
+
+	job.LogInfo("Got an import job of type ", job.jobData["type"])
+
+	// Delete the job when we have finished processing it
+	job.Delete()
+}
+
+func (job *ImportJobHandler) validateJobData() error {
+	// Required fields on our job
+	requiredFields := []string{"type"}
+
+	// Check all required fields have a value set
+	for _, field := range requiredFields {
+		value, exists := job.jobData[field]
+		if !exists {
+			return fmt.Errorf("Field %s not found in job data", field)
+		}
+
+		if value == "" {
+			return fmt.Errorf("Field %s should not be empty", field)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds a worker example that uses a signal handler to cancel the context and cleanly shutdown the worker.

Example is go installable inside the examples directory