### PR TITLE
switches back to upstream go-beanstalk package

### DIFF
--- a/job.go
+++ b/job.go
@@ -1,7 +1,7 @@
 package beanstalkworker
 
 import "time"
-import "github.com/tomponline/beanstalk"
+import "github.com/beanstalkd/go-beanstalk"
 
 // JobManager interface represents a way to handle a job's lifecycle.
 type JobManager interface {

--- a/rawJob.go
+++ b/rawJob.go
@@ -1,7 +1,7 @@
 package beanstalkworker
 
 import "time"
-import "github.com/tomponline/beanstalk"
+import "github.com/beanstalkd/go-beanstalk"
 import "fmt"
 
 // Actions the user can choose in case of an unmarshal error.

--- a/worker.go
+++ b/worker.go
@@ -3,7 +3,7 @@ package beanstalkworker
 import (
 	"context"
 	"encoding/json"
-	"github.com/tomponline/beanstalk"
+	"github.com/beanstalkd/go-beanstalk"
 	"reflect"
 	"strconv"
 	"sync"


### PR DESCRIPTION
Now that my network timeout patch has been merged in upstream, we can switch back to upstream go-beanstalk package.

See https://github.com/beanstalkd/go-beanstalk/pull/26