### PR TITLE
Adds the Touch function

### DIFF
--- a/job.go
+++ b/job.go
@@ -6,6 +6,7 @@ import "github.com/beanstalkd/go-beanstalk"
 // JobManager interface represents a way to handle a job's lifecycle.
 type JobManager interface {
 	Delete()
+	Touch()
 	Release()
 	LogError(a ...interface{})
 	LogInfo(a ...interface{})

--- a/rawJob.go
+++ b/rawJob.go
@@ -53,7 +53,7 @@ func (job *RawJob) Delete() {
 
 // Touch function touches the job from the queue.
 func (job *RawJob) Touch() {
-	if err := job.conn.Delete(job.id); err != nil {
+	if err := job.conn.Touch(job.id); err != nil {
 		job.log.Error("Could not touch job: " + err.Error())
 	}
 }

--- a/rawJob.go
+++ b/rawJob.go
@@ -51,6 +51,13 @@ func (job *RawJob) Delete() {
 	}
 }
 
+// Touch function touches the job from the queue.
+func (job *RawJob) Touch() {
+	if err := job.conn.Delete(job.id); err != nil {
+		job.log.Error("Could not touch job: " + err.Error())
+	}
+}
+
 // Release function releases the job from the queue.
 func (job *RawJob) Release() {
 	if err := job.conn.Release(job.id, job.returnPrio, job.returnDelay); err != nil {


### PR DESCRIPTION
Beanstalk Protocol provides the `Touch` command which allows a worker to request more time to work on a job. In situations where `timeouts` are an issue, this command will be useful in order to delay the auto release of the reserved job, thereby given the worker more time to complete the job.

Implementation:
- Adds Touch function
- Adds Touch to the Job Manager interface